### PR TITLE
Add third-party-licenses.txt Output Type

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	Allow []string `hcl:"allow,optional"`
 	Deny  []string `hcl:"deny,optional"`
 
+	// Preapproved is a list of import paths that have been "preapproved",
+	// either because the license is non-standard or approved as a one-off.
 	Preapproved []string `hcl:"preapproved,optional"`
 
 	// Override is a map that explicitly sets the license for the given
@@ -33,12 +35,12 @@ type Config struct {
 }
 
 // Allowed returns the allowed state of a license given the configuration.
-func (c *Config) Allowed(p string, l *license.License) AllowState {
+func (c *Config) Allowed(importPath string, l *license.License) AllowState {
 	if l == nil {
 		return StateDenied // no license is never allowed
 	}
 
-	path := strings.ToLower(p)
+	path := strings.ToLower(importPath)
 	name := strings.ToLower(l.Name)
 	spdx := strings.ToLower(l.SPDX)
 
@@ -57,6 +59,7 @@ func (c *Config) Allowed(p string, l *license.License) AllowState {
 		}
 	}
 
+	// Allow repos that are pre-approved
 	for _, v := range c.Preapproved {
 		v = strings.ToLower(v)
 		if path == v {
@@ -67,8 +70,10 @@ func (c *Config) Allowed(p string, l *license.License) AllowState {
 	return StateUnknown
 }
 
+// AllowState - Is the repo/license allowed?
 type AllowState int
 
+// Possible AllowStates
 const (
 	StateUnknown AllowState = iota
 	StateAllowed

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	Allow []string `hcl:"allow,optional"`
 	Deny  []string `hcl:"deny,optional"`
 
-	Ignore []string `hcl:"ignore,optional"`
+	Preapproved []string `hcl:"preapproved,optional"`
 
 	// Override is a map that explicitly sets the license for the given
 	// import path. The key is an import path (exact) and the value is
@@ -57,7 +57,7 @@ func (c *Config) Allowed(p string, l *license.License) AllowState {
 		}
 	}
 
-	for _, v := range c.Ignore {
+	for _, v := range c.Preapproved {
 		v = strings.ToLower(v)
 		if path == v {
 			return StateAllowed

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	Allow []string `hcl:"allow,optional"`
 	Deny  []string `hcl:"deny,optional"`
 
+	Ignore []string `hcl:"ignore,optional"`
+
 	// Override is a map that explicitly sets the license for the given
 	// import path. The key is an import path (exact) and the value is
 	// the name or SPDX ID of the license. Regardless, the value will
@@ -31,11 +33,12 @@ type Config struct {
 }
 
 // Allowed returns the allowed state of a license given the configuration.
-func (c *Config) Allowed(l *license.License) AllowState {
+func (c *Config) Allowed(p string, l *license.License) AllowState {
 	if l == nil {
 		return StateDenied // no license is never allowed
 	}
 
+	path := strings.ToLower(p)
 	name := strings.ToLower(l.Name)
 	spdx := strings.ToLower(l.SPDX)
 
@@ -50,6 +53,13 @@ func (c *Config) Allowed(l *license.License) AllowState {
 	for _, v := range c.Allow {
 		v = strings.ToLower(v)
 		if name == v || spdx == v {
+			return StateAllowed
+		}
+	}
+
+	for _, v := range c.Ignore {
+		v = strings.ToLower(v)
+		if path == v {
 			return StateAllowed
 		}
 	}

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github/v18 v18.2.0 h1:s7Y4I8ZlIL1Ofxpj4AQRJcSGAr0Jl2AHThHgXpsUCfU=
 github.com/google/go-github/v18 v18.2.0/go.mod h1:Bf4Ut1RTeH0WuX7Z4Zf7N+qp/YqgcFOxvTLuSO+aY/k=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/license/github/detect.go
+++ b/license/github/detect.go
@@ -41,7 +41,6 @@ func detect(rl *github.RepositoryLicense) (*license.License, error) {
 	return &license.License{
 		Name: lic.Name,
 		SPDX: lic.ID,
-		Text: lic.Text,
 	}, nil
 }
 

--- a/license/github/detect.go
+++ b/license/github/detect.go
@@ -41,6 +41,7 @@ func detect(rl *github.RepositoryLicense) (*license.License, error) {
 	return &license.License{
 		Name: lic.Name,
 		SPDX: lic.ID,
+		Text: lic.Text,
 	}, nil
 }
 

--- a/license/github/repo_api.go
+++ b/license/github/repo_api.go
@@ -57,18 +57,27 @@ FETCH_RETRY:
 		return nil, err
 	}
 
+	strName := rl.GetLicense().GetName()
+	strSPDX := rl.GetLicense().GetSPDXID()
+
 	// If the license type is "other" then we try to use go-license-detector
 	// to determine the license, which seems to be accurate in these cases.
 	if rl.GetLicense().GetKey() == "other" {
-		return detect(rl)
+		lic, err := detect(rl)
+
+		if err == nil {
+			strName = lic.String()
+			strSPDX = lic.SPDXString()
+		}
 	}
 
 	content, _ := base64.StdEncoding.DecodeString(rl.GetContent())
+	strContent := string(content)
 
 	return &license.License{
-		Name: rl.GetLicense().GetName(),
-		SPDX: rl.GetLicense().GetSPDXID(),
-		Text: string(content),
+		Name: strName,
+		SPDX: strSPDX,
+		Text: strContent,
 	}, nil
 }
 

--- a/license/github/repo_api.go
+++ b/license/github/repo_api.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"time"
@@ -62,9 +63,12 @@ FETCH_RETRY:
 		return detect(rl)
 	}
 
+	content, _ := base64.StdEncoding.DecodeString(rl.GetContent())
+
 	return &license.License{
 		Name: rl.GetLicense().GetName(),
 		SPDX: rl.GetLicense().GetSPDXID(),
+		Text: string(content),
 	}, nil
 }
 

--- a/license/github/repo_api.go
+++ b/license/github/repo_api.go
@@ -66,7 +66,7 @@ FETCH_RETRY:
 		lic, err := detect(rl)
 
 		if err == nil {
-			strName = lic.String()
+			strName = lic.NameString()
 			strSPDX = lic.SPDXString()
 		}
 	}

--- a/license/license.go
+++ b/license/license.go
@@ -6,10 +6,11 @@ package license
 type License struct {
 	Name string // Name is a human-friendly name like "MIT License"
 	SPDX string // SPDX ID of the license, blank if unknown or unavailable
-	Text string // License text
+	Text string // License text is the full content of the license file
 }
 
-func (l *License) String() string {
+// NameString - get the stringified license name
+func (l *License) NameString() string {
 	if l == nil {
 		return "<license not found or detected>"
 	}
@@ -17,6 +18,7 @@ func (l *License) String() string {
 	return l.Name
 }
 
+// TextString - get the stringified license text
 func (l *License) TextString() string {
 	if l == nil {
 		return "<license not found or detected>"
@@ -25,6 +27,7 @@ func (l *License) TextString() string {
 	return l.Text
 }
 
+// SPDXString - get the stringified SPDX type
 func (l *License) SPDXString() string {
 	if l == nil {
 		return "<license not found or detected>"

--- a/license/license.go
+++ b/license/license.go
@@ -24,3 +24,11 @@ func (l *License) TextString() string {
 
 	return l.Text
 }
+
+func (l *License) SPDXString() string {
+	if l == nil {
+		return "<license not found or detected>"
+	}
+
+	return l.SPDX
+}

--- a/license/license.go
+++ b/license/license.go
@@ -6,6 +6,7 @@ package license
 type License struct {
 	Name string // Name is a human-friendly name like "MIT License"
 	SPDX string // SPDX ID of the license, blank if unknown or unavailable
+	Text string // License text
 }
 
 func (l *License) String() string {
@@ -14,4 +15,12 @@ func (l *License) String() string {
 	}
 
 	return l.Name
+}
+
+func (l *License) TextString() string {
+	if l == nil {
+		return "<license not found or detected>"
+	}
+
+	return l.Text
 }

--- a/license/mapper/finder.go
+++ b/license/mapper/finder.go
@@ -27,6 +27,5 @@ func (f *Finder) License(ctx context.Context, m module.Module) (*license.License
 	if err != nil {
 		return nil, fmt.Errorf("Override license %q SPDX lookup error: %s", v, err)
 	}
-
-	return &license.License{Name: lic.Name, SPDX: lic.ID}, nil
+	return &license.License{Name: lic.Name, SPDX: lic.ID, Text: lic.Text}, nil
 }

--- a/license/mapper/finder.go
+++ b/license/mapper/finder.go
@@ -27,5 +27,8 @@ func (f *Finder) License(ctx context.Context, m module.Module) (*license.License
 	if err != nil {
 		return nil, fmt.Errorf("Override license %q SPDX lookup error: %s", v, err)
 	}
-	return &license.License{Name: lic.Name, SPDX: lic.ID, Text: lic.Text}, nil
+	return &license.License{
+		Name: lic.Name,
+		SPDX: lic.ID,
+		Text: lic.Text}, nil
 }

--- a/main.go
+++ b/main.go
@@ -126,7 +126,6 @@ func realMain() int {
 			Config: &cfg,
 		})
 	}
-
 	if flagOutLicenseFile != "" {
 		out.Outputs = append(out.Outputs, &LicenseFileOutput{
 			Path:   flagOutLicenseFile,

--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ func realMain() int {
 
 	var flagLicense bool
 	var flagOutXLSX string
+	var flagOutLicenseFile string
+
 	flags := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	flags.BoolVar(&flagLicense, "license", true,
 		"look up and verify license. If false, dependencies are\n"+
@@ -45,6 +47,8 @@ func realMain() int {
 	flags.BoolVar(&termOut.Verbose, "verbose", false, "additional logging to terminal, requires -plain")
 	flags.StringVar(&flagOutXLSX, "out-xlsx", "",
 		"save report in Excel XLSX format to the given path")
+	flags.StringVar(&flagOutLicenseFile, "out-licensefile", "",
+		"save file of concatenated license text")
 	flags.Parse(os.Args[1:])
 	args := flags.Args()
 	if len(args) == 0 {
@@ -119,6 +123,13 @@ func realMain() int {
 	if flagOutXLSX != "" {
 		out.Outputs = append(out.Outputs, &XLSXOutput{
 			Path:   flagOutXLSX,
+			Config: &cfg,
+		})
+	}
+
+	if flagOutLicenseFile != "" {
+		out.Outputs = append(out.Outputs, &LicenseFileOutput{
+			Path:   flagOutLicenseFile,
 			Config: &cfg,
 		})
 	}

--- a/output_licensefile.go
+++ b/output_licensefile.go
@@ -11,14 +11,13 @@ import (
 	"github.com/mitchellh/golicense/module"
 )
 
-// LicenseFileOutput writes the results of license lookups to an XLSX file.
+// LicenseFileOutput writes the results of license lookups to a text file.
+// The output file will contain the import path, version, and full license text for each dependency.
 type LicenseFileOutput struct {
-	// Path is the path to the file to write. This will be overwritten if
-	// it exists.
+	// Path - the path to the file to write. This will be overwritten if it exists.
 	Path string
 
-	// Config is the configuration (if any). This will be used to check
-	// if a license is allowed or not.
+	// Config - the configuration (if any). This will be used to check if a license is allowed or not.
 	Config *config.Config
 
 	modules map[*module.Module]interface{}
@@ -66,16 +65,15 @@ func (o *LicenseFileOutput) Close() error {
 	}
 	sort.Strings(keys)
 
-	// Go through each module and output it into the spreadsheet
+	// Go through each module and write the data to the licensefile
 	for _, k := range keys {
 		m := index[k]
 		raw := o.modules[m]
 
-		// if raw == nil {
 		fmt.Fprintln(f, fmt.Sprintf(
 			"%s - %s\n", m.Path, m.Version))
 
-		// If the value is a license, then mark the license
+		// Extract the license data and write to the licensefile
 		if lic, ok := raw.(*license.License); ok {
 			if lic != nil {
 				fmt.Fprintln(f, lic.SPDX)
@@ -85,8 +83,6 @@ func (o *LicenseFileOutput) Close() error {
 			fmt.Fprintln(f, "**LICENSE NOT FOUND!**")
 		}
 		fmt.Fprintln(f, "##########")
-
-		// }
 	}
 	// Save
 	if err := f.Close(); err != nil {

--- a/output_licensefile.go
+++ b/output_licensefile.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/mitchellh/golicense/config"
+	"github.com/mitchellh/golicense/license"
+	"github.com/mitchellh/golicense/module"
+)
+
+// LicenseFileOutput writes the results of license lookups to an XLSX file.
+type LicenseFileOutput struct {
+	// Path is the path to the file to write. This will be overwritten if
+	// it exists.
+	Path string
+
+	// Config is the configuration (if any). This will be used to check
+	// if a license is allowed or not.
+	Config *config.Config
+
+	modules map[*module.Module]interface{}
+	lock    sync.Mutex
+}
+
+// Start implements Output
+func (o *LicenseFileOutput) Start(m *module.Module) {}
+
+// Update implements Output
+func (o *LicenseFileOutput) Update(m *module.Module, t license.StatusType, msg string) {}
+
+// Finish implements Output
+func (o *LicenseFileOutput) Finish(m *module.Module, l *license.License, err error) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	if o.modules == nil {
+		o.modules = make(map[*module.Module]interface{})
+	}
+
+	o.modules[m] = l
+	if err != nil {
+		o.modules[m] = err
+	}
+}
+
+// Close implements Output
+func (o *LicenseFileOutput) Close() error {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	f, err := os.Create(o.Path)
+
+	if err != nil {
+		return err
+	}
+
+	// Sort the modules by name
+	keys := make([]string, 0, len(o.modules))
+	index := map[string]*module.Module{}
+	for m := range o.modules {
+		keys = append(keys, m.Path)
+		index[m.Path] = m
+	}
+	sort.Strings(keys)
+
+	// Go through each module and output it into the spreadsheet
+	for _, k := range keys {
+		m := index[k]
+		raw := o.modules[m]
+
+		// if raw == nil {
+		fmt.Fprintln(f, fmt.Sprintf(
+			"%s - %s\n", m.Path, m.Version))
+
+		// If the value is a license, then mark the license
+		if lic, ok := raw.(*license.License); ok {
+			if lic != nil {
+				fmt.Fprintln(f, lic.SPDX)
+				fmt.Fprintln(f, lic.TextString())
+				fmt.Fprintln(f, "##########")
+			}
+		}
+		// }
+	}
+	// Save
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/output_licensefile.go
+++ b/output_licensefile.go
@@ -80,9 +80,12 @@ func (o *LicenseFileOutput) Close() error {
 			if lic != nil {
 				fmt.Fprintln(f, lic.SPDX)
 				fmt.Fprintln(f, lic.TextString())
-				fmt.Fprintln(f, "##########")
 			}
+		} else {
+			fmt.Fprintln(f, "**LICENSE NOT FOUND!**")
 		}
+		fmt.Fprintln(f, "##########")
+
 		// }
 	}
 	// Save

--- a/output_terminal.go
+++ b/output_terminal.go
@@ -112,7 +112,7 @@ func (o *TermOutput) Finish(m *module.Module, l *license.License, err error) {
 	var colorFunc func(string, ...interface{}) string = fmt.Sprintf
 	icon := iconNormal
 	if o.Config != nil {
-		state := o.Config.Allowed(l)
+		state := o.Config.Allowed(m.Path, l)
 		switch state {
 		case config.StateAllowed:
 			colorFunc = color.GreenString

--- a/output_terminal.go
+++ b/output_terminal.go
@@ -137,7 +137,7 @@ func (o *TermOutput) Finish(m *module.Module, l *license.License, err error) {
 
 	if o.Plain {
 		fmt.Fprintf(o.Out, fmt.Sprintf(
-			"%s %s\n", o.paddedModule(m), l.String()))
+			"%s %s\n", o.paddedModule(m), l.NameString()))
 		return
 	}
 
@@ -146,7 +146,7 @@ func (o *TermOutput) Finish(m *module.Module, l *license.License, err error) {
 	delete(o.modules, m.Path)
 	o.pauseLive(func() {
 		o.live.Write([]byte(colorFunc(
-			"%s%s %s\n", icon, o.paddedModule(m), l.String())))
+			"%s%s %s\n", icon, o.paddedModule(m), l.NameString())))
 	})
 }
 

--- a/output_xlsx.go
+++ b/output_xlsx.go
@@ -123,7 +123,7 @@ func (o *XLSXOutput) Close() error {
 			if lic != nil {
 				f.SetCellValue(s, fmt.Sprintf("C%d", i+2), lic.SPDX)
 			}
-			f.SetCellValue(s, fmt.Sprintf("D%d", i+2), lic.String())
+			f.SetCellValue(s, fmt.Sprintf("D%d", i+2), lic.NameString())
 			if o.Config != nil {
 				switch o.Config.Allowed(m.Path, lic) {
 				case config.StateAllowed:

--- a/output_xlsx.go
+++ b/output_xlsx.go
@@ -125,7 +125,7 @@ func (o *XLSXOutput) Close() error {
 			}
 			f.SetCellValue(s, fmt.Sprintf("D%d", i+2), lic.String())
 			if o.Config != nil {
-				switch o.Config.Allowed(lic) {
+				switch o.Config.Allowed(m.Path, lic) {
 				case config.StateAllowed:
 					f.SetCellValue(s, fmt.Sprintf("E%d", i+2), "yes")
 					f.SetCellStyle(s, "A"+row, "A"+row, greenStyle)


### PR DESCRIPTION
https://github.com/mitchellh/golicense/pull/17

Adds a new output type via -output-licensefile that dumps the following information for each dependency to the file name specified:

    Import path
    Version
    Full license text

Also added is a new configuration type to allow for "pre-approved" licenses (e.g. imports with non-standard licenses that need manual review). This is different from "overrides", which forces a given import path to be treated as having a specific license type (e.g. MIT).